### PR TITLE
Fix client initSpotifyLogin func to use current deploy domain for nonce cookie

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,5 @@
 /** Dynamic URL of site from Vite base url */
-const deployUrl = new URL(import.meta.url).origin;
+const deployUrl = new URL(import.meta.url);
 
 /** Generate nonce and redirect user to backend login endpoint to start Spotify auth process */
 function initSpotifyLogin() {
@@ -7,11 +7,11 @@ function initSpotifyLogin() {
   const nonce = Math.floor(Math.random() * (99999999 - 10000000) + 10000000);
 
   // Store as cookie
-  const nonceCookie = `exportify-nonce=${nonce}; Path=/api; SameSite=lax; Max-Age=300; Domain=localhost`;
+  const nonceCookie = `exportify-nonce=${nonce}; Path=/api; SameSite=lax; Max-Age=300; Domain=${deployUrl.hostname}`;
   document.cookie = nonceCookie;
 
   // Redirect browser to /api/login to begin Spotify auth process
-  window.location.assign(`${deployUrl}/api/login`);
+  window.location.assign(`${deployUrl.origin}/api/login`);
 }
 
 /** Checks cookies to confirm whether user has an access token */


### PR DESCRIPTION
Fixes #10 

Adjusted the `deployUrl` var to just parse into URL obj, rather than extracting the `origin` prop specifically.

- The `window.location.assign` redirect now references the `origin` prop of `deployUrl` obj
- Nonce cookie initialisation string references `hostname` prop of `deployUrl` obj