### PR TITLE
Fix target dyndb table based on deploy context

### DIFF
--- a/functions/auth/auth.ts
+++ b/functions/auth/auth.ts
@@ -19,11 +19,9 @@ const DYNAMODB_ACCESS_KEY_ID = Netlify.env.get("DYNAMODB_ACCESS_KEY_ID") || "";
 const DYNAMODB_ACCESS_KEY_SECRET =
   Netlify.env.get("DYNAMODB_ACCESS_KEY_SECRET") || "";
 const DYNAMODB_TABLE_NAME =
-  DEPLOY_CONTEXT === "production"
-    ? "ExportifyStateToken"
-    : "ExportifyDevStateToken";
+  DEPLOY_CONTEXT === "dev" ? "ExportifyDevStateToken" : "ExportifyStateToken";
 const dbClient = new DynamoDBClient({
-  region: DEPLOY_CONTEXT === "production" ? "us-east-2" : "ap-southeast-2",
+  region: DEPLOY_CONTEXT === "dev" ? "ap-southeast-2" : "us-east-2",
   credentials: {
     accessKeyId: DYNAMODB_ACCESS_KEY_ID,
     secretAccessKey: DYNAMODB_ACCESS_KEY_SECRET,

--- a/functions/login/login.ts
+++ b/functions/login/login.ts
@@ -13,11 +13,9 @@ const DYNAMODB_ACCESS_KEY_ID = Netlify.env.get("DYNAMODB_ACCESS_KEY_ID") || "";
 const DYNAMODB_ACCESS_KEY_SECRET =
   Netlify.env.get("DYNAMODB_ACCESS_KEY_SECRET") || "";
 const DYNAMODB_TABLE_NAME =
-  DEPLOY_CONTEXT === "production"
-    ? "ExportifyStateToken"
-    : "ExportifyDevStateToken";
+  DEPLOY_CONTEXT === "dev" ? "ExportifyDevStateToken" : "ExportifyStateToken";
 const dbClient = new DynamoDBClient({
-  region: DEPLOY_CONTEXT === "production" ? "us-east-2" : "ap-southeast-2",
+  region: DEPLOY_CONTEXT === "dev" ? "ap-southeast-2" : "us-east-2",
   credentials: {
     accessKeyId: DYNAMODB_ACCESS_KEY_ID,
     secretAccessKey: DYNAMODB_ACCESS_KEY_SECRET,


### PR DESCRIPTION
I'm only using prod and dev contexts at the moment until I fix my branch/deploy preview problems with custom domain redirects. Netlify might have changed their deploy context value for production even though I've referenced the docs.

Rather than troubleshooting that, I'm flipping it to check for dev for now as I've got branch/deploy previews completely disabled. I'd like to reassess how this target name & region is defined anyway when I add the branch/deploy contexts as well.