### PR TITLE
Use origin value of deployUrl for location header value in /api/auth

### DIFF
--- a/functions/auth/auth.ts
+++ b/functions/auth/auth.ts
@@ -166,7 +166,8 @@ export default async (req: Request, context: Context) => {
     return new Response(null, {
       status: 302,
       headers: new Headers([
-        ["Location", deployUrl.toString()],
+        // Using deployUrl.origin here ensures that Spotify API's query strings are dropped when redirecting client back from /api/auth to base / route.
+        ["Location", deployUrl.origin],
         [
           "Set-Cookie",
           `exportify-token=${spotifyAccessToken}; Domain=${deployUrl.hostname}; Path=/api; Max-Age=3600; SameSite=strict; HttpOnly;`,


### PR DESCRIPTION
Genuinely the last cheeky little bug found in prod that wasn't appearing in dev environment. Would have caught this one in a branch preview/deploy preview for sure.

When user finished Spotify auth and followed their redirect to my /api/auth function with code & state query params, these query params were being passed through to client when Location header value redirected them back to the main app route.

This was because I was parsing context.site.url from Netlify's context object & calling toString() on the URL, which seems to include query string params in a prod environment but not locally.

Adjusting my URL.toString() call into referencing the URL.origin prop ensures that query params are dropped in the Location header value from /api/auth, and user shouldn't receive the query params in their browser's URL bar.